### PR TITLE
Fixed grouped DB headings not receiving bg color

### DIFF
--- a/theming/theme.css
+++ b/theming/theme.css
@@ -47,7 +47,8 @@ body,
 .notion-update-sidebar-tab-updates-header + .notion-scroller,
 .notion-update-sidebar-tab-comments-header,
 .notion-update-sidebar-tab-comments-header + div,
-.notion-code-block > div > div > [style*='background: '][style$='padding-right: 105px;'] {
+.notion-code-block > div > div > [style*='background: '][style$='padding-right: 105px;'],
+[style*='z-index: 84'] {
   background: var(--theme--bg) !important;
 }
 .notion-timeline-item-row + div > div > div,


### PR DESCRIPTION
Thoroughly tested every DB view and group type and the style z-index: 84 does appear to be exclusive to this element.

BEFORE MAKING A PULL REQUEST, PLEASE READ THE
[CONTRIBUTING](https://notion-enhancer.github.io/about/contributing) GUIDE.

PULL REQUESTS THAT DO NOT PROPERLY FILL
IN THE TEMPLATE MAY BE IGNORED OR REJECTED.
YOU MUST DELETE ALL TEXT ON OR ABOVE THIS LINE BEFORE SUBMITTING.

**Which bug report or feature request do these changes address?**
https://github.com/notion-enhancer/notion-enhancer/issues/878

**What does your code do and why?**
Adds [style*='z-index: 84'] to the selectors which receive the --theme-bg variable to fix certain grouped DB headings retaining default notion colors. Thoroughly tested and this style selector is exclusive to those affected elements.