### PR TITLE
toggle header indentation lines, adjacent tab nav hotkeys

### DIFF
--- a/indentation-lines/client.css
+++ b/indentation-lines/client.css
@@ -9,6 +9,9 @@
 .notion-page-content .notion-numbered_list-block > div > div:last-child,
 .notion-page-content .notion-to_do-block > div > div:last-child,
 .notion-page-content .notion-toggle-block > div > div:last-child,
+.notion-page-content .notion-selectable.notion-sub_header-block > div > div > div:last-child,
+.notion-page-content .notion-selectable.notion-sub_sub_header-block > div > div > div:last-child,
+.notion-page-content .notion-selectable.notion-sub_sub_sub_header-block > div > div > div:last-child,
 .notion-page-content .notion-table_of_contents-block > div > div > a > div > div {
   position: relative;
 }
@@ -16,7 +19,11 @@
 .notion-page-content .notion-bulleted_list-block > div > div:last-child::before,
 .notion-page-content .notion-numbered_list-block > div > div:last-child::before,
 .notion-page-content .notion-to_do-block > div > div:last-child::before,
-.notion-page-content .notion-toggle-block > div > div:last-child::before {
+.notion-page-content .notion-toggle-block > div > div:last-child::before,
+.notion-page-content .notion-selectable.notion-sub_header-block > div > div > div:last-child::before,
+.notion-page-content .notion-selectable.notion-sub_sub_header-block > div > div > div:last-child::before,
+.notion-page-content .notion-selectable.notion-sub_sub_sub_header-block > div > div > div:last-child::before,
+.notion-page-content .pseudoSelection > div > div:last-child::before {
   content: '';
   position: absolute;
   height: calc(100% - 2em);
@@ -93,3 +100,4 @@
   > .plus:hover {
   background: var(--theme--ui_interactive-hover) !important;
 }
+

--- a/indentation-lines/client.mjs
+++ b/indentation-lines/client.mjs
@@ -48,7 +48,21 @@ export default async function ({ web }, db) {
       }
     }
   }
-
+  if (await db.get(['toggle_header'])) {
+    css += `
+      .notion-page-content .notion-selectable.notion-sub_sub_header-block > div > div > div:last-child::before {
+        border-left: 1px ${style} var(--indentation_lines--color, currentColor);
+        opacity: ${opacity};
+      }
+      .notion-page-content .notion-selectable.notion-sub_header-block > div > div > div:last-child::before {
+        border-left: 1px ${style} var(--indentation_lines--color, currentColor);
+        opacity: ${opacity};
+      }
+      .notion-page-content .notion-selectable.notion-sub_sub_sub_header-block > div > div > div:last-child::before {
+        border-left: 1px ${style} var(--indentation_lines--color, currentColor);
+        opacity: ${opacity};
+      }`;
+  }
   if (db.get(['table_of_contents'])) {
     css += `
       .notion-page-content .notion-table_of_contents-block > div > div > a > div

--- a/indentation-lines/mod.json
+++ b/indentation-lines/mod.json
@@ -52,6 +52,12 @@
     },
     {
       "type": "toggle",
+      "key": "toggle_header",
+      "label": "toggle headers",
+      "value": true
+    },
+    {
+      "type": "toggle",
       "key": "table_of_contents",
       "label": "tables of contents",
       "value": true

--- a/tabs/client.mjs
+++ b/tabs/client.mjs
@@ -10,14 +10,14 @@ export default async function ({ web, electron }, db) {
   const newTabHotkey = await db.get(['new_tab']),
     closeTabHotkey = await db.get(['close_tab']),
     restoreTabHotkey = await db.get(['restore_tab']),
-    selectTabModifier = await db.get(['select_modifier']);
+    selectTabModifier = await db.get(['select_modifier']),
+    prevTabHotkey = await db.get(['prev_tab']),
+    nextTabHotkey = await db.get(['next_tab']);
   web.addHotkeyListener(newTabHotkey, () => {
     electron.sendMessageToHost('new-tab');
-    console.log('new-tab');
   });
   web.addHotkeyListener(restoreTabHotkey, () => {
     electron.sendMessageToHost('restore-tab');
-    console.log('restore-tab');
   });
   web.addHotkeyListener(closeTabHotkey, () => electron.sendMessageToHost('close-tab'));
   for (let i = 1; i < 10; i++) {
@@ -25,6 +25,12 @@ export default async function ({ web, electron }, db) {
       electron.sendMessageToHost('select-tab', i);
     });
   }
+  web.addHotkeyListener(prevTabHotkey, () => {
+    electron.sendMessageToHost('select-prev-tab')
+  });
+  web.addHotkeyListener(nextTabHotkey, () => {
+    electron.sendMessageToHost('select-next-tab')
+  }); 
 
   const breadcrumbSelector =
       '.notion-topbar > div > [class="notranslate"] > .notion-focusable:last-child',

--- a/tabs/mod.json
+++ b/tabs/mod.json
@@ -64,6 +64,18 @@
     },
     {
       "type": "hotkey",
+      "key": "prev_tab",
+      "label": "previous tab hotkey",
+      "value": "Control+Shift+Tab"
+    },
+    {
+      "type": "hotkey",
+      "key": "next_tab",
+      "label": "next tab hotkey",
+      "value": "Control+Tab"
+    },
+    {
+      "type": "hotkey",
       "key": "new_tab",
       "label": "new tab hotkey",
       "value": "Control+T"

--- a/tabs/tab.cjs
+++ b/tabs/tab.cjs
@@ -228,6 +228,36 @@ module.exports = async function (api, db, tabCache = new Map()) {
         const $tab = i === 9 ? this.$tabList.lastElementChild : this.$tabList.children[i - 1];
         if ($tab) $tab.click();
       });
+      fromNotion('notion-enhancer:select-prev-tab', () => {
+        if (this.$tabList.count == 1) {
+          return;
+        }
+        const $sibling = this.$tab.previousElementSibling;
+        if ($sibling) {
+          $sibling.click();
+        }
+        else {
+          let $tab = this.$tabList.lastElementChild;
+          if ($tab) {
+            $tab.click();
+          }
+        }
+      });
+      fromNotion('notion-enhancer:select-next-tab', () => {
+        if (this.$tabList.count == 1) {
+          return;
+        }
+        const $sibling = this.$tab.nextElementSibling;
+        if ($sibling) {
+          $sibling.click();
+        }
+        else {
+          let $tab = this.$tabList.children[0]
+          if ($tab) {
+            $tab.click();
+          }
+        }
+      });
     }
 
     #firstQuery = true;


### PR DESCRIPTION
**Which bug report or feature request do these changes address?**

This code should add functionality for indentation lines for all toggle header sizes, which wasn't implemented when toggle headers were released.

**What does your code do and why?**

Follows syntax of the rest of the code made by the original creator. Adds support for all line modes BESIDES rainbow (for the moment). Will finish that later, but will be more challenging than the other list types.

I had one issue where I would toggle the toggle headers off in the notion-enhancer menu, and the indentation lines would still stay on, but as far as I'm concerned I have fixed it.