### PR TITLE
Theme: smooth dark

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -37,6 +37,7 @@
   "cherry-cola",
   "dark+",
   "light+",
+  "smooth-dark",
   "dracula",
   "pastel-dark",
   "neutral",

--- a/smooth-dark/app.css
+++ b/smooth-dark/app.css
@@ -1,0 +1,190 @@
+/**
+ * notion-enhancer: smooth dark
+ * (c) 2022 blorbb (https://github.com/blorbb)
+ * (https://notion-enhancer.github.io/) under the MIT license
+ */
+
+/* rounded highlight corners */
+/* gray, orange, yellow, green, blue, purple, pink, red*/
+.notion-body:not(.dark)
+  [style*='background: rgba(241, 241, 239, 1)']:not([style*='border-radius']):not([style*='box-shadow']),
+.notion-body:not(.dark)
+  [style*='background:rgba(241, 241, 239, 1)']:not([style*='border-radius']):not([style*='box-shadow']),
+.notion-body:not(.dark)
+  [style*='background: rgb(241, 241, 239)']:not([style*='border-radius']):not([style*='box-shadow']),
+.notion-body:not(.dark)
+  [style*='background:rgb(241, 241, 239)']:not([style*='border-radius']):not([style*='box-shadow']),
+.notion-body:not(.dark)
+  [style*='background-color: rgba(241, 241, 239, 1)']:not([style*='border-radius']):not([style*='box-shadow']),
+.notion-body.dark
+  [style*='background: rgba(60, 65, 68, 1)']:not([style*='border-radius']):not([style*='box-shadow']),
+.notion-body.dark
+  [style*='background:rgba(60, 65, 68, 1)']:not([style*='border-radius']):not([style*='box-shadow']),
+.notion-body.dark
+  [style*='background: rgb(60, 65, 68)']:not([style*='border-radius']):not([style*='box-shadow']),
+.notion-body.dark
+  [style*='background:rgb(60, 65, 68)']:not([style*='border-radius']):not([style*='box-shadow']),
+.notion-body.dark
+  [style*='background-color: rgba(60, 65, 68, 1)']:not([style*='border-radius']):not([style*='box-shadow']),
+.notion-body:not(.dark)
+  [style*='background: rgba(244, 238, 238, 1)']:not([style*='border-radius']):not([style*='box-shadow']),
+.notion-body:not(.dark)
+  [style*='background:rgba(244, 238, 238, 1)']:not([style*='border-radius']):not([style*='box-shadow']),
+.notion-body:not(.dark)
+  [style*='background: rgb(244, 238, 238)']:not([style*='border-radius']):not([style*='box-shadow']),
+.notion-body:not(.dark)
+  [style*='background:rgb(244, 238, 238)']:not([style*='border-radius']):not([style*='box-shadow']),
+.notion-body:not(.dark)
+  [style*='background-color: rgba(244, 238, 238, 1)']:not([style*='border-radius']):not([style*='box-shadow']),
+.notion-body.dark
+  [style*='background: rgba(76, 61, 53, 1)']:not([style*='border-radius']):not([style*='box-shadow']),
+.notion-body.dark
+  [style*='background:rgba(76, 61, 53, 1)']:not([style*='border-radius']):not([style*='box-shadow']),
+.notion-body.dark
+  [style*='background: rgb(76, 61, 53)']:not([style*='border-radius']):not([style*='box-shadow']),
+.notion-body.dark
+  [style*='background:rgb(76, 61, 53)']:not([style*='border-radius']):not([style*='box-shadow']),
+.notion-body.dark
+  [style*='background-color: rgba(76, 61, 53, 1)']:not([style*='border-radius']):not([style*='box-shadow']),
+.notion-body:not(.dark)
+  [style*='background: rgba(251, 236, 221, 1)']:not([style*='border-radius']):not([style*='box-shadow']),
+.notion-body:not(.dark)
+  [style*='background:rgba(251, 236, 221, 1)']:not([style*='border-radius']):not([style*='box-shadow']),
+.notion-body:not(.dark)
+  [style*='background: rgb(251, 236, 221)']:not([style*='border-radius']):not([style*='box-shadow']),
+.notion-body:not(.dark)
+  [style*='background:rgb(251, 236, 221)']:not([style*='border-radius']):not([style*='box-shadow']),
+.notion-body:not(.dark)
+  [style*='background-color: rgba(251, 236, 221, 1)']:not([style*='border-radius']):not([style*='box-shadow']),
+.notion-body.dark
+  [style*='background: rgba(85, 59, 41, 1)']:not([style*='border-radius']):not([style*='box-shadow']),
+.notion-body.dark
+  [style*='background:rgba(85, 59, 41, 1)']:not([style*='border-radius']):not([style*='box-shadow']),
+.notion-body.dark
+  [style*='background: rgb(85, 59, 41)']:not([style*='border-radius']):not([style*='box-shadow']),
+.notion-body.dark
+  [style*='background:rgb(85, 59, 41)']:not([style*='border-radius']):not([style*='box-shadow']),
+.notion-body.dark
+  [style*='background-color: rgba(85, 59, 41, 1)']:not([style*='border-radius']):not([style*='box-shadow']),
+.notion-body:not(.dark)
+  [style*='background: rgba(251, 243, 219, 1)']:not([style*='border-radius']):not([style*='box-shadow']),
+.notion-body:not(.dark)
+  [style*='background:rgba(251, 243, 219, 1)']:not([style*='border-radius']):not([style*='box-shadow']),
+.notion-body:not(.dark)
+  [style*='background: rgb(251, 243, 219)']:not([style*='border-radius']):not([style*='box-shadow']),
+.notion-body:not(.dark)
+  [style*='background:rgb(251, 243, 219)']:not([style*='border-radius']):not([style*='box-shadow']),
+.notion-body:not(.dark)
+  [style*='background-color: rgba(251, 243, 219, 1)']:not([style*='border-radius']):not([style*='box-shadow']),
+.notion-body.dark
+  [style*='background: rgba(79, 64, 41, 1)']:not([style*='border-radius']):not([style*='box-shadow']),
+.notion-body.dark
+  [style*='background:rgba(79, 64, 41, 1)']:not([style*='border-radius']):not([style*='box-shadow']),
+.notion-body.dark
+  [style*='background: rgb(79, 64, 41)']:not([style*='border-radius']):not([style*='box-shadow']),
+.notion-body.dark
+  [style*='background:rgb(79, 64, 41)']:not([style*='border-radius']):not([style*='box-shadow']),
+.notion-body.dark
+  [style*='background-color: rgba(79, 64, 41, 1)']:not([style*='border-radius']):not([style*='box-shadow']),
+.notion-body:not(.dark)
+  [style*='background: rgba(237, 243, 236, 1)']:not([style*='border-radius']):not([style*='box-shadow']),
+.notion-body:not(.dark)
+  [style*='background:rgba(237, 243, 236, 1)']:not([style*='border-radius']):not([style*='box-shadow']),
+.notion-body:not(.dark)
+  [style*='background: rgb(237, 243, 236)']:not([style*='border-radius']):not([style*='box-shadow']),
+.notion-body:not(.dark)
+  [style*='background:rgb(237, 243, 236)']:not([style*='border-radius']):not([style*='box-shadow']),
+.notion-body:not(.dark)
+  [style*='background-color: rgba(237, 243, 236, 1)']:not([style*='border-radius']):not([style*='box-shadow']),
+.notion-body.dark
+  [style*='background: rgba(46, 68, 58, 1)']:not([style*='border-radius']):not([style*='box-shadow']),
+.notion-body.dark
+  [style*='background:rgba(46, 68, 58, 1)']:not([style*='border-radius']):not([style*='box-shadow']),
+.notion-body.dark
+  [style*='background: rgb(46, 68, 58)']:not([style*='border-radius']):not([style*='box-shadow']),
+.notion-body.dark
+  [style*='background:rgb(46, 68, 58)']:not([style*='border-radius']):not([style*='box-shadow']),
+.notion-body.dark
+  [style*='background-color: rgba(46, 68, 58, 1)']:not([style*='border-radius']):not([style*='box-shadow']),
+.notion-body:not(.dark)
+  [style*='background: rgba(231, 243, 248, 1)']:not([style*='border-radius']):not([style*='box-shadow']),
+.notion-body:not(.dark)
+  [style*='background:rgba(231, 243, 248, 1)']:not([style*='border-radius']):not([style*='box-shadow']),
+.notion-body:not(.dark)
+  [style*='background: rgb(231, 243, 248)']:not([style*='border-radius']):not([style*='box-shadow']),
+.notion-body:not(.dark)
+  [style*='background:rgb(231, 243, 248)']:not([style*='border-radius']):not([style*='box-shadow']),
+.notion-body:not(.dark)
+  [style*='background-color: rgba(231, 243, 248, 1)']:not([style*='border-radius']):not([style*='box-shadow']),
+.notion-body.dark
+  [style*='background: rgba(45, 66, 86, 1)']:not([style*='border-radius']):not([style*='box-shadow']),
+.notion-body.dark
+  [style*='background:rgba(45, 66, 86, 1)']:not([style*='border-radius']):not([style*='box-shadow']),
+.notion-body.dark
+  [style*='background: rgb(45, 66, 86)']:not([style*='border-radius']):not([style*='box-shadow']),
+.notion-body.dark
+  [style*='background:rgb(45, 66, 86)']:not([style*='border-radius']):not([style*='box-shadow']),
+.notion-body.dark
+  [style*='background-color: rgba(45, 66, 86, 1)']:not([style*='border-radius']):not([style*='box-shadow']),
+.notion-body:not(.dark)
+  [style*='background: rgba(244, 240, 247, 0.8)']:not([style*='border-radius']):not([style*='box-shadow']),
+.notion-body:not(.dark)
+  [style*='background:rgba(244, 240, 247, 0.8)']:not([style*='border-radius']):not([style*='box-shadow']),
+.notion-body:not(.dark)
+  [style*='background: rgba(244, 240, 247, 0.8)']:not([style*='border-radius']):not([style*='box-shadow']),
+.notion-body:not(.dark)
+  [style*='background:rgba(244, 240, 247, 0.8)']:not([style*='border-radius']):not([style*='box-shadow']),
+.notion-body:not(.dark)
+  [style*='background-color: rgba(244, 240, 247, 0.8)']:not([style*='border-radius']):not([style*='box-shadow']),
+.notion-body.dark
+  [style*='background: rgba(69, 58, 91, 1)']:not([style*='border-radius']):not([style*='box-shadow']),
+.notion-body.dark
+  [style*='background:rgba(69, 58, 91, 1)']:not([style*='border-radius']):not([style*='box-shadow']),
+.notion-body.dark
+  [style*='background: rgb(69, 58, 91)']:not([style*='border-radius']):not([style*='box-shadow']),
+.notion-body.dark
+  [style*='background:rgb(69, 58, 91)']:not([style*='border-radius']):not([style*='box-shadow']),
+.notion-body.dark
+  [style*='background-color: rgba(69, 58, 91, 1)']:not([style*='border-radius']):not([style*='box-shadow']),
+.notion-body:not(.dark)
+  [style*='background: rgba(249, 238, 243, 0.8)']:not([style*='border-radius']):not([style*='box-shadow']),
+.notion-body:not(.dark)
+  [style*='background:rgba(249, 238, 243, 0.8)']:not([style*='border-radius']):not([style*='box-shadow']),
+.notion-body:not(.dark)
+  [style*='background: rgba(249, 238, 243, 0.8)']:not([style*='border-radius']):not([style*='box-shadow']),
+.notion-body:not(.dark)
+  [style*='background:rgba(249, 238, 243, 0.8)']:not([style*='border-radius']):not([style*='box-shadow']),
+.notion-body:not(.dark)
+  [style*='background-color: rgba(249, 238, 243, 0.8)']:not([style*='border-radius']):not([style*='box-shadow']),
+.notion-body.dark
+  [style*='background: rgba(81, 56, 77, 1)']:not([style*='border-radius']):not([style*='box-shadow']),
+.notion-body.dark
+  [style*='background:rgba(81, 56, 77, 1)']:not([style*='border-radius']):not([style*='box-shadow']),
+.notion-body.dark
+  [style*='background: rgb(81, 56, 77)']:not([style*='border-radius']):not([style*='box-shadow']),
+.notion-body.dark
+  [style*='background:rgb(81, 56, 77)']:not([style*='border-radius']):not([style*='box-shadow']),
+.notion-body.dark
+  [style*='background-color: rgba(81, 56, 77, 1)']:not([style*='border-radius']):not([style*='box-shadow']),
+.notion-body:not(.dark)
+  [style*='background: rgba(253, 235, 236, 1)']:not([style*='border-radius']):not([style*='box-shadow']),
+.notion-body:not(.dark)
+  [style*='background:rgba(253, 235, 236, 1)']:not([style*='border-radius']):not([style*='box-shadow']),
+.notion-body:not(.dark)
+  [style*='background: rgb(253, 235, 236)']:not([style*='border-radius']):not([style*='box-shadow']),
+.notion-body:not(.dark)
+  [style*='background:rgb(253, 235, 236)']:not([style*='border-radius']):not([style*='box-shadow']),
+.notion-body:not(.dark)
+  [style*='background-color: rgba(253, 235, 236, 1)']:not([style*='border-radius']):not([style*='box-shadow']),
+.notion-body.dark
+  [style*='background: rgba(94, 52, 54, 1)']:not([style*='border-radius']):not([style*='box-shadow']),
+.notion-body.dark
+  [style*='background:rgba(94, 52, 54, 1)']:not([style*='border-radius']):not([style*='box-shadow']),
+.notion-body.dark
+  [style*='background: rgb(94, 52, 54)']:not([style*='border-radius']):not([style*='box-shadow']),
+.notion-body.dark
+  [style*='background:rgb(94, 52, 54)']:not([style*='border-radius']):not([style*='box-shadow']),
+.notion-body.dark
+  [style*='background-color: rgba(94, 52, 54, 1)']:not([style*='border-radius']):not([style*='box-shadow']) {
+  border-radius: calc(var(--smooth_dark--highlight-border-radius, 3) * 1px) !important;
+}

--- a/smooth-dark/mod.json
+++ b/smooth-dark/mod.json
@@ -1,0 +1,76 @@
+{
+  "name": "smooth dark",
+  "id": "46fdda12-d614-4154-a313-61619d1732a8",
+  "version": "0.1.0",
+  "description": "a highly configurable dark theme.",
+  "preview": "smooth-dark.png",
+  "tags": ["theme", "dark"],
+  "authors": [
+    {
+      "name": "blorb",
+      "homepage": "https://github.com/blorbb",
+      "avatar": "https://avatars.githubusercontent.com/u/88137137"
+    }
+  ],
+  "css": {
+    "frame": ["variables.css"],
+    "client": ["variables.css", "app.css"],
+    "menu": ["variables.css"]
+  },
+  "js": {
+    "frame": ["theme.mjs"],
+    "client": ["theme.mjs"],
+    "menu": ["theme.mjs"]
+  },
+  "options": [
+    {
+      "type": "color",
+      "key": "background",
+      "label": "background color",
+      "tooltip": "**sets the background color** affects many other elements that are based on the background",
+      "value": "rgba(33, 39, 52, 1)"
+    },
+    {
+      "type": "color",
+      "key": "primary",
+      "label": "primary accent color",
+      "tooltip": "**replaces notion's blue accent**",
+      "value": "rgba(255, 171, 0, 1)"
+    },
+    {
+      "type": "color",
+      "key": "secondary",
+      "label": "secondary accent color",
+      "tooltip": "**replaces notion's red accent**",
+      "value": "rgba(235, 87, 87, 1)"
+    },
+    {
+      "type": "number",
+      "key": "bg_secondary_tint",
+      "tooltip": "**sidebar and cal/timeline weekends brightness**, based on the background: positive values brighten, negative values darken (-100 to 100)",
+      "label": "background secondary overlay (%)",
+      "value": -13
+    },
+    {
+      "type": "number",
+      "key": "bg_card_tint",
+      "tooltip": "**cards and popup menu brightness**, based on the background: positive values brighten, negative values darken (-100 to 100)",
+      "label": "card overlay (%)",
+      "value": 7
+    },
+    {
+      "type": "select",
+      "key": "color_profile",
+      "tooltip": "**pastel: lighter highlights, highlighted text is black for better contrast. regular: more saturated highlights, highlighted text stays white.**",
+      "label": "color type",
+      "values": ["pastel", "regular"]
+    },
+    {
+      "type": "number",
+      "key": "border_radius",
+      "tooltip": "**adds rounding to the corner of highlighted text** (non-negative integer)",
+      "label": "highlight border radius (px)",
+      "value": 3
+    }
+  ]
+}

--- a/smooth-dark/mod.json
+++ b/smooth-dark/mod.json
@@ -62,7 +62,7 @@
       "type": "select",
       "key": "color_profile",
       "tooltip": "**pastel: lighter highlights, highlighted text is black for better contrast. regular: more saturated highlights, highlighted text stays white.**",
-      "label": "color type",
+      "label": "color profile",
       "values": ["pastel", "regular"]
     },
     {

--- a/smooth-dark/theme.mjs
+++ b/smooth-dark/theme.mjs
@@ -1,0 +1,549 @@
+/**
+ * notion-enhancer: smooth dark
+ * (c) 2022 blorbb (https://github.com/blorbb)
+ * (https://notion-enhancer.github.io/) under the MIT license
+ */
+
+'use strict';
+
+function rgbLinearShade(amount, color) {
+  const int = parseInt,
+    round = Math.round,
+    [r, g, b, a] = color.split(','),
+    flip = 1 - Math.abs(amount);
+  let [newR, newG, newB] = [
+    flip * int(r[3] == 'a' ? r.slice(5) : r.slice(4)),
+    flip * int(g),
+    flip * int(b),
+  ];
+  if (amount > 0) {
+    const scaledAmount = 255 * amount;
+    [newR, newG, newB] = [scaledAmount + newR, scaledAmount + newG, scaledAmount + newB];
+  }
+  return (
+    'rgb' +
+    (a ? 'a(' : '(') +
+    round(newR) +
+    ',' +
+    round(newG) +
+    ',' +
+    round(newB) +
+    (a ? ',' + a : ')')
+  );
+}
+
+export default async function ({ fmt }, db) {
+  {
+    const background = await db.get(['background']),
+      bgSecondaryTint = await db.get(['bg_secondary_tint']),
+      cardTint = await db.get(['bg_card_tint']),
+      [r, g, b] = background
+        .slice(5, -1)
+        .split(',')
+        .map((i) => parseInt(i));
+
+    if (!(r === 33 && g === 39 && b === 52)) {
+      document.documentElement.style.setProperty('--smooth_dark--bg', background);
+      // other bg dependent colors
+      document.documentElement.style.setProperty(
+        '--smooth_dark--ui_corner_action',
+        rgbLinearShade(0.09, background)
+      );
+      document.documentElement.style.setProperty(
+        '--smooth_dark--ui_corner_action-hover',
+        rgbLinearShade(0.14, background)
+      );
+      document.documentElement.style.setProperty(
+        '--smooth_dark--ui_corner_action-active',
+        rgbLinearShade(0.2, background)
+      );
+      // with some opacity
+      document.documentElement.style.setProperty(
+        '--smooth_dark--code',
+        rgbLinearShade(0.15, `rgba(${r}, ${g}, ${b}, 0.8)`)
+      );
+    }
+
+
+
+    document.documentElement.style.setProperty(
+      '--smooth_dark--bg_secondary',
+      rgbLinearShade(bgSecondaryTint / 100, background)
+    );
+
+    document.documentElement.style.setProperty(
+      '--smooth_dark--bg_card',
+      rgbLinearShade(cardTint / 100, background)
+    );
+  }
+
+  {
+    const primary = await db.get(['primary']),
+      [r, g, b] = primary
+        .slice(5, -1)
+        .split(',')
+        .map((i) => parseInt(i));
+    if (!(r === 255 && g === 171 && b === 0)) {
+      document.documentElement.style.setProperty('--smooth_dark--accent_blue', primary);
+      document.documentElement.style.setProperty(
+        '--smooth_dark--accent_blue-selection',
+        `rgba(${r},${g},${b},0.2)`
+      );
+      document.documentElement.style.setProperty(
+        '--smooth_dark--accent_blue-hover',
+        rgbLinearShade(0.07, primary)
+      );
+      document.documentElement.style.setProperty(
+        '--smooth_dark--accent_blue-active',
+        rgbLinearShade(0.16, primary)
+      );
+      document.documentElement.style.setProperty(
+        '--smooth_dark--accent_blue-text',
+        fmt.rgbContrast(r, g, b)
+      );
+    }
+  }
+
+  {
+    const secondary = await db.get(['secondary']),
+      [r, g, b] = secondary
+        .slice(5, -1)
+        .split(',')
+        .map((i) => parseInt(i));
+    if (!(r === 235 && g === 87 && b === 87)) {
+      document.documentElement.style.setProperty('--smooth_dark--accent_red', secondary);
+      document.documentElement.style.setProperty(
+        '--smooth_dark--accent_red-button',
+        `rgba(${r},${g},${b},0.1)`
+      );
+      document.documentElement.style.setProperty(
+        '--smooth_dark--accent_red-text',
+        fmt.rgbContrast(r, g, b)
+      );
+    }
+  }
+
+  {
+    const borderRadius = await db.get(['border_radius']);
+    if (borderRadius !== 3) {
+      document.documentElement.style.setProperty(
+        '--smooth_dark--highlight-border-radius',
+        borderRadius
+      );
+    }
+  }
+
+  {
+    const colorProfile = await db.get(['color_profile']);
+    if (colorProfile === 'regular') {
+      // highlight text: white
+      document.documentElement.style.setProperty(
+        '--smooth_dark--highlight-text',
+        'rgba(255, 255, 255, 1)'
+      );
+
+      // text colors: lch(70%, 55, hue)
+      document.documentElement.style.setProperty(
+        '--smooth_dark--text_red',
+        'rgba(255, 133, 124, 1)'
+      );
+      document.documentElement.style.setProperty(
+        '--smooth_dark--text_orange',
+        'rgba(233, 151, 84, 1)'
+      );
+      document.documentElement.style.setProperty(
+        '--smooth_dark--text_yellow',
+        'rgba(216, 179, 100, 1)'
+      );
+      document.documentElement.style.setProperty(
+        '--smooth_dark--text_green',
+        'rgba(121, 188, 89, 1)'
+      );
+      document.documentElement.style.setProperty(
+        '--smooth_dark--text_blue',
+        'rgba(69, 180, 255, 1)'
+      );
+      document.documentElement.style.setProperty(
+        '--smooth_dark--text_purple',
+        'rgba(185, 155, 255, 1)'
+      );
+      document.documentElement.style.setProperty(
+        '--smooth_dark--text_pink',
+        'rgba(255, 126, 174, 1)'
+      );
+      document.documentElement.style.setProperty(
+        '--smooth_dark--text_gray',
+        'rgba(171, 171, 171, 1)'
+      );
+      document.documentElement.style.setProperty(
+        '--smooth_dark--text_brown',
+        'rgba(184, 114, 56, 1)' // lch(55%, 50, 60)
+      );
+
+      // highlight background: lch(65%, 60, hue)
+      document.documentElement.style.setProperty(
+        '--smooth_dark--highlight_red',
+        'rgba(227, 106, 99, 1)'
+      );
+      document.documentElement.style.setProperty(
+        '--smooth_dark--highlight_orange',
+        'rgba(203, 124, 60, 1)'
+      );
+      document.documentElement.style.setProperty(
+        '--smooth_dark--highlight_yellow',
+        'rgba(195, 158, 70, 1)'
+      );
+      document.documentElement.style.setProperty(
+        '--smooth_dark--highlight_green',
+        'rgba(94, 160, 64, 1)'
+      );
+      document.documentElement.style.setProperty(
+        '--smooth_dark--highlight_blue',
+        'rgb(49, 142, 196)' // slightly less saturated
+      );
+      document.documentElement.style.setProperty(
+        '--smooth_dark--highlight_purple',
+        'rgba(157, 129, 229, 1)'
+      );
+      document.documentElement.style.setProperty(
+        '--smooth_dark--highlight_pink',
+        'rgba(229, 99, 147, 1)'
+      );
+      document.documentElement.style.setProperty(
+        '--smooth_dark--highlight_gray',
+        'rgb(145, 145, 145, 0.5)'
+      );
+      document.documentElement.style.setProperty(
+        '--smooth_dark--highlight_brown',
+        'rgba(174, 99, 35, 1)' // lch(50%, 55, 60)
+      );
+
+      // callouts: same as highlights with 80% saturation and 30% opacity
+      document.documentElement.style.setProperty(
+        '--smooth_dark--callout_red',
+        'rgba(215, 117, 112, 0.3)'
+      );
+      document.documentElement.style.setProperty(
+        '--smooth_dark--callout_orange',
+        'rgba(189, 127, 76, 0.3)'
+      );
+      document.documentElement.style.setProperty(
+        '--smooth_dark--callout_yellow',
+        'rgba(183, 153, 82, 0.3)'
+      );
+      document.documentElement.style.setProperty(
+        '--smooth_dark--callout_green',
+        'rgba(98, 150, 74, 0.3)'
+      );
+      document.documentElement.style.setProperty(
+        '--smooth_dark--callout_blue',
+        'rgba(64, 138, 181, 0.3)'
+      );
+      document.documentElement.style.setProperty(
+        '--smooth_dark--callout_purple',
+        'rgba(161, 138, 219, 0.3)'
+      );
+      document.documentElement.style.setProperty(
+        '--smooth_dark--callout_pink',
+        'rgba(216, 111, 149, 0.3)'
+      );
+      document.documentElement.style.setProperty(
+        '--smooth_dark--callout_gray',
+        'rgba(145, 145, 145, 0.15)'
+      );
+      document.documentElement.style.setProperty(
+        '--smooth_dark--callout_brown',
+        'rgba(183, 129, 87, 0.3)'
+      );
+
+      // tag bg: lch(70%, 40, hue)
+      document.documentElement.style.setProperty(
+        '--smooth_dark--tag_red',
+        'rgba(242, 119, 112, 0.9)'
+      );
+      document.documentElement.style.setProperty(
+        '--smooth_dark--tag_orange',
+        'rgba(218, 137, 72, 0.9)'
+      );
+      document.documentElement.style.setProperty(
+        '--smooth_dark--tag_yellow',
+        'rgba(199, 168, 102, 0.9)'
+      );
+      document.documentElement.style.setProperty(
+        '--smooth_dark--tag_green',
+        'rgba(108, 174, 77, 0.9)'
+      );
+      document.documentElement.style.setProperty(
+        '--smooth_dark--tag_blue',
+        'hsla(206, 60%, 59%, 0.9)' // lower saturation
+      );
+      document.documentElement.style.setProperty(
+        '--smooth_dark--tag_purple',
+        'rgba(171, 142, 244, 0.9)'
+      );
+      document.documentElement.style.setProperty(
+        '--smooth_dark--tag_pink',
+        'rgba(244, 112, 160, 0.9)'
+      );
+      document.documentElement.style.setProperty(
+        '--smooth_dark--tag_gray',
+        'rgba(145, 145, 145, 0.9)'
+      );
+      document.documentElement.style.setProperty(
+        '--smooth_dark--tag_light_gray',
+        'rgba(171, 171, 171, 0.9)'
+      );
+      document.documentElement.style.setProperty(
+        '--smooth_dark--tag_brown',
+        'rgba(170, 101, 44, 0.9)' // lch(50%, 50, 60)
+      );
+
+      // boards: same as tags at half opacity
+      document.documentElement.style.setProperty(
+        '--smooth_dark--board_red',
+        'rgba(242, 119, 112, 0.45)'
+      );
+      document.documentElement.style.setProperty(
+        '--smooth_dark--board_orange',
+        'rgba(218, 137, 72, 0.45)'
+      );
+      document.documentElement.style.setProperty(
+        '--smooth_dark--board_yellow',
+        'rgba(199, 168, 102, 0.45)'
+      );
+      document.documentElement.style.setProperty(
+        '--smooth_dark--board_green',
+        'rgba(108, 174, 77, 0.45)'
+      );
+      document.documentElement.style.setProperty(
+        '--smooth_dark--board_blue',
+        'rgba(82, 160, 218, 0.45)'
+      );
+      document.documentElement.style.setProperty(
+        '--smooth_dark--board_purple',
+        'rgba(171, 142, 244, 0.45)'
+      );
+      document.documentElement.style.setProperty(
+        '--smooth_dark--board_pink',
+        'rgba(244, 112, 160, 0.45)'
+      );
+      document.documentElement.style.setProperty(
+        '--smooth_dark--board_gray',
+        'rgba(145, 145, 145, 0.45)'
+      );
+      document.documentElement.style.setProperty(
+        '--smooth_dark--board_light_gray',
+        'rgba(171, 171, 171, 0.45)'
+      );
+      document.documentElement.style.setProperty(
+        '--smooth_dark--board_brown',
+        'rgba(170, 101, 44, 0.45)'
+      );
+    } else if (colorProfile === 'pastel') {
+      // highlight text: black
+      document.documentElement.style.setProperty(
+        '--smooth_dark--highlight-text',
+        'rgba(0, 0, 0, 1)'
+      );
+
+      // text colors: lch(65%, 50, hue)
+      document.documentElement.style.setProperty(
+        '--smooth_dark--text_red',
+        'rgba(235, 124, 116, 1)'
+      );
+      document.documentElement.style.setProperty(
+        '--smooth_dark--text_orange',
+        'rgba(214, 139, 80, 1)'
+      );
+      document.documentElement.style.setProperty(
+        '--smooth_dark--text_yellow',
+        'rgba(191, 151, 66, 1)'
+      );
+      document.documentElement.style.setProperty(
+        '--smooth_dark--text_green',
+        'rgba(114, 173, 85, 1)'
+      );
+      document.documentElement.style.setProperty(
+        '--smooth_dark--text_blue',
+        'rgba(71, 165, 246, 1)'
+      );
+      document.documentElement.style.setProperty(
+        '--smooth_dark--text_purple',
+        'rgba(90, 163, 226, 1)'  // lowered saturation
+      );
+      document.documentElement.style.setProperty(
+        '--smooth_dark--text_pink',
+        'rgba(237, 118, 160, 1)'
+      );
+      document.documentElement.style.setProperty(
+        '--smooth_dark--text_gray',
+        'rgba(145, 145, 145, 1)'
+      );
+      document.documentElement.style.setProperty(
+        '--smooth_dark--text_brown',
+        'rgba(176, 118, 72, 1)' // lch(55%, 40, 60)
+      );
+
+      // highlight background: lch(75%, 40, hue)
+      document.documentElement.style.setProperty(
+        '--smooth_dark--highlight_red',
+        'rgba(252, 159, 150, 0.9)'
+      );
+      document.documentElement.style.setProperty(
+        '--smooth_dark--highlight_orange',
+        'rgba(234, 170, 122, 0.9)'
+      );
+      document.documentElement.style.setProperty(
+        '--smooth_dark--highlight_yellow',
+        'rgba(214, 179, 111, 0.9)'
+      );
+      document.documentElement.style.setProperty(
+        '--smooth_dark--highlight_green',
+        'rgba(151, 197, 126, 0.9)'
+      );
+      document.documentElement.style.setProperty(
+        '--smooth_dark--highlight_blue',
+        'rgba(147, 191, 236, 0.9)' // lowered saturation
+      );
+      document.documentElement.style.setProperty(
+        '--smooth_dark--highlight_purple',
+        'rgba(197, 173, 249, 0.9)'
+      );
+      document.documentElement.style.setProperty(
+        '--smooth_dark--highlight_pink',
+        'rgba(252, 155, 187, 0.9)'
+      );
+      // probably used more as an elevation than actual highlight - lowered opacity
+      document.documentElement.style.setProperty(
+        '--smooth_dark--highlight_gray',
+        'rgba(158, 158, 158, 0.45)'
+      );
+      document.documentElement.style.setProperty(
+        '--smooth_dark--highlight_brown',
+        'rgba(176, 118, 72, 0.9)' // lch(55%, 40, 60)
+      );
+
+      // callours: highlight colors with half opacity
+      document.documentElement.style.setProperty(
+        '--smooth_dark--callout_red',
+        'rgba(252, 159, 150, 0.35)'
+      );
+      document.documentElement.style.setProperty(
+        '--smooth_dark--callout_orange',
+        'rgba(234, 170, 122, 0.35)'
+      );
+      document.documentElement.style.setProperty(
+        '--smooth_dark--callout_yellow',
+        'rgba(214, 179, 111, 0.35)'
+      );
+      document.documentElement.style.setProperty(
+        '--smooth_dark--callout_green',
+        'rgba(151, 197, 126, 0.35)'
+      );
+      document.documentElement.style.setProperty(
+        '--smooth_dark--callout_blue',
+        'rgba(147, 191, 236, 0.35)'
+      );
+      document.documentElement.style.setProperty(
+        '--smooth_dark--callout_purple',
+        'rgba(197, 173, 249, 0.35)'
+      );
+      document.documentElement.style.setProperty(
+        '--smooth_dark--callout_pink',
+        'rgba(252, 155, 187, 0.35)'
+      );
+      document.documentElement.style.setProperty(
+        '--smooth_dark--callout_gray',
+        'rgba(158, 158, 158, 0.18)' // lowered opacity for elevation
+      );
+      document.documentElement.style.setProperty(
+        '--smooth_dark--callout_brown',
+        'rgba(176, 118, 72, 0.35)'
+      );
+
+      // tag bg: lch(70%, 45, hue)
+      document.documentElement.style.setProperty(
+        '--smooth_dark--tag_red',
+        'rgba(244, 142, 133, 0.8)'
+      );
+      document.documentElement.style.setProperty(
+        '--smooth_dark--tag_orange',
+        'rgba(224, 155, 101, 0.8)'
+      );
+      document.documentElement.style.setProperty(
+        '--smooth_dark--tag_yellow',
+        'hsla(40, 60%, 57%, 0.8)'
+      );
+      document.documentElement.style.setProperty(
+        '--smooth_dark--tag_green',
+        'rgba(132, 185, 105, 0.8)'
+      );
+      document.documentElement.style.setProperty(
+        '--smooth_dark--tag_blue',
+        'rgba(101, 176, 251, 0.8)'
+      );
+      document.documentElement.style.setProperty(
+        '--smooth_dark--tag_purple',
+        'rgba(184, 159, 242, 0.8)'
+      );
+      document.documentElement.style.setProperty(
+        '--smooth_dark--tag_pink',
+        'rgba(245, 137, 173, 0.8)'
+      );
+      document.documentElement.style.setProperty(
+        '--smooth_dark--tag_gray',
+        'rgba(145, 145, 145, 0.8)'
+      );
+      document.documentElement.style.setProperty(
+        '--smooth_dark--tag_light_gray',
+        'rgba(171, 171, 171, 0.8)'
+      );
+      document.documentElement.style.setProperty(
+        '--smooth_dark--tag_brown',
+        'rgba(195, 128, 76, 0.8)' // lch(60%, 45, 60)
+      );
+
+      // boards: same as tags at half opacity
+      document.documentElement.style.setProperty(
+        '--smooth_dark--board_red',
+        'rgba(244, 142, 133, 0.4)'
+      );
+      document.documentElement.style.setProperty(
+        '--smooth_dark--board_orange',
+        'rgba(224, 155, 101, 0.4)'
+      );
+      document.documentElement.style.setProperty(
+        '--smooth_dark--board_yellow',
+        'hsla(40, 60%, 57%, 0.4)'
+      );
+      document.documentElement.style.setProperty(
+        '--smooth_dark--board_green',
+        'rgba(132, 185, 105, 0.4)'
+      );
+      document.documentElement.style.setProperty(
+        '--smooth_dark--board_blue',
+        'rgba(101, 176, 251, 0.4)'
+      );
+      document.documentElement.style.setProperty(
+        '--smooth_dark--board_purple',
+        'rgba(184, 159, 242, 0.4)'
+      );
+      document.documentElement.style.setProperty(
+        '--smooth_dark--board_pink',
+        'rgba(245, 137, 173, 0.4)'
+      );
+      document.documentElement.style.setProperty(
+        '--smooth_dark--board_gray',
+        'rgba(145, 145, 145, 0.4)'
+      );
+      document.documentElement.style.setProperty(
+        '--smooth_dark--board_light_gray',
+        'rgba(171, 171, 171, 0.4)'
+      );
+      document.documentElement.style.setProperty(
+        '--smooth_dark--board_brown',
+        'rgba(195, 128, 76, 0.4)'
+      );
+    }
+  }
+}

--- a/smooth-dark/theme.mjs
+++ b/smooth-dark/theme.mjs
@@ -42,38 +42,34 @@ export default async function ({ fmt }, db) {
         .split(',')
         .map((i) => parseInt(i));
 
-    if (!(r === 33 && g === 39 && b === 52)) {
-      document.documentElement.style.setProperty('--smooth_dark--bg', background);
-      // other bg dependent colors
-      document.documentElement.style.setProperty(
-        '--smooth_dark--ui_corner_action',
-        rgbLinearShade(0.09, background)
-      );
-      document.documentElement.style.setProperty(
-        '--smooth_dark--ui_corner_action-hover',
-        rgbLinearShade(0.14, background)
-      );
-      document.documentElement.style.setProperty(
-        '--smooth_dark--ui_corner_action-active',
-        rgbLinearShade(0.2, background)
-      );
-      // with some opacity
-      document.documentElement.style.setProperty(
-        '--smooth_dark--code',
-        rgbLinearShade(0.15, `rgba(${r}, ${g}, ${b}, 0.8)`)
-      );
-    }
-
-
-
+    // backgrounds
+    document.documentElement.style.setProperty('--smooth_dark--bg', background);
     document.documentElement.style.setProperty(
       '--smooth_dark--bg_secondary',
       rgbLinearShade(bgSecondaryTint / 100, background)
     );
-
     document.documentElement.style.setProperty(
       '--smooth_dark--bg_card',
       rgbLinearShade(cardTint / 100, background)
+    );
+
+    // other bg dependent colors
+    document.documentElement.style.setProperty(
+      '--smooth_dark--ui_corner_action',
+      rgbLinearShade(0.09, background)
+    );
+    document.documentElement.style.setProperty(
+      '--smooth_dark--ui_corner_action-hover',
+      rgbLinearShade(0.14, background)
+    );
+    document.documentElement.style.setProperty(
+      '--smooth_dark--ui_corner_action-active',
+      rgbLinearShade(0.2, background)
+    );
+    // with some opacity
+    document.documentElement.style.setProperty(
+      '--smooth_dark--code',
+      rgbLinearShade(0.15, `rgba(${r}, ${g}, ${b}, 0.8)`)
     );
   }
 
@@ -83,25 +79,25 @@ export default async function ({ fmt }, db) {
         .slice(5, -1)
         .split(',')
         .map((i) => parseInt(i));
-    if (!(r === 255 && g === 171 && b === 0)) {
-      document.documentElement.style.setProperty('--smooth_dark--accent_blue', primary);
-      document.documentElement.style.setProperty(
-        '--smooth_dark--accent_blue-selection',
-        `rgba(${r},${g},${b},0.2)`
-      );
-      document.documentElement.style.setProperty(
-        '--smooth_dark--accent_blue-hover',
-        rgbLinearShade(0.07, primary)
-      );
-      document.documentElement.style.setProperty(
-        '--smooth_dark--accent_blue-active',
-        rgbLinearShade(0.16, primary)
-      );
-      document.documentElement.style.setProperty(
-        '--smooth_dark--accent_blue-text',
-        fmt.rgbContrast(r, g, b)
-      );
-    }
+
+    // primary colors
+    document.documentElement.style.setProperty('--smooth_dark--accent_blue', primary);
+    document.documentElement.style.setProperty(
+      '--smooth_dark--accent_blue-selection',
+      `rgba(${r},${g},${b},0.2)`
+    );
+    document.documentElement.style.setProperty(
+      '--smooth_dark--accent_blue-hover',
+      rgbLinearShade(0.07, primary)
+    );
+    document.documentElement.style.setProperty(
+      '--smooth_dark--accent_blue-active',
+      rgbLinearShade(0.16, primary)
+    );
+    document.documentElement.style.setProperty(
+      '--smooth_dark--accent_blue-text',
+      fmt.rgbContrast(r, g, b)
+    );
   }
 
   {
@@ -110,17 +106,17 @@ export default async function ({ fmt }, db) {
         .slice(5, -1)
         .split(',')
         .map((i) => parseInt(i));
-    if (!(r === 235 && g === 87 && b === 87)) {
-      document.documentElement.style.setProperty('--smooth_dark--accent_red', secondary);
-      document.documentElement.style.setProperty(
-        '--smooth_dark--accent_red-button',
-        `rgba(${r},${g},${b},0.1)`
-      );
-      document.documentElement.style.setProperty(
-        '--smooth_dark--accent_red-text',
-        fmt.rgbContrast(r, g, b)
-      );
-    }
+
+    // secondary colors
+    document.documentElement.style.setProperty('--smooth_dark--accent_red', secondary);
+    document.documentElement.style.setProperty(
+      '--smooth_dark--accent_red-button',
+      `rgba(${r},${g},${b},0.1)`
+    );
+    document.documentElement.style.setProperty(
+      '--smooth_dark--accent_red-text',
+      fmt.rgbContrast(r, g, b)
+    );
   }
 
   {
@@ -369,7 +365,7 @@ export default async function ({ fmt }, db) {
       );
       document.documentElement.style.setProperty(
         '--smooth_dark--text_purple',
-        'rgba(90, 163, 226, 1)'  // lowered saturation
+        'rgba(90, 163, 226, 1)' // lower saturation
       );
       document.documentElement.style.setProperty(
         '--smooth_dark--text_pink',

--- a/smooth-dark/variables.css
+++ b/smooth-dark/variables.css
@@ -1,0 +1,207 @@
+/**
+ * notion-enhancer: smooth dark
+ * (c) 2022 blorbb (https://github.com/blorbb)
+ * (https://notion-enhancer.github.io/) under the MIT license
+ */
+
+:root.dark {
+  --smooth_dark--highlight-text: rgba(255, 255, 255, 1); /* changed in pastel mode */
+  --smooth_dark--board-card: rgba(255, 255, 255, 0.05);
+  --smooth_dark--tag-text: #fff;
+
+  --theme--accent_blue: var(--smooth_dark--accent_blue, rgb(255, 171, 0));
+  --theme--accent_blue-selection: var(
+    --smooth_dark--accent_blue-selection,
+    rgba(255, 171, 0, 0.2)
+  );
+  --theme--accent_blue-hover: var(--smooth_dark--accent_blue-hover, rgb(255, 177, 18));
+  --theme--accent_blue-active: var(--smooth_dark--accent_blue-active, rgb(255, 184, 41));
+  --theme--accent_blue-text: var(--smooth_dark--accent_blue-text, #fff);
+  --theme--accent_red: var(--smooth_dark--accent_red, #eb5757);
+  --theme--accent_red-button: var(
+    --smooth_dark--accent_red-button,
+    rgba(235, 87, 87, 0.1)
+  );
+  --theme--accent_red-text: var(--smooth_dark--accent_red-text, #fff);
+  --a: ;
+  --theme--bg: var(--smooth_dark--bg, rgb(33, 39, 52));
+  --theme--bg_secondary: var(--smooth_dark--bg_secondary);
+  --theme--bg_card: var(--smooth_dark--bg_card);
+
+  --theme--scrollbar_track: transparent;
+  --theme--scrollbar_thumb: rgba(255, 255, 255, 0.05);
+  --theme--scrollbar_thumb-hover: rgba(255, 255, 255, 0.07);
+
+  --theme--ui_shadow: rgba(0, 0, 0, 0.09);
+  --theme--ui_divider: rgba(255, 255, 255, 0.16);
+  --theme--ui_interactive-hover: rgba(255, 255, 255, 0.07);
+  --theme--ui_interactive-active: rgba(255, 255, 255, 0.16);
+  --theme--ui_toggle-on: var(--theme--accent_blue);
+  --theme--ui_toggle-off: rgba(255, 255, 255, 0.05);
+  --theme--ui_corner_action: var(--smooth_dark--ui_corner_action, rgb(53, 58, 70));
+  --theme--ui_corner_action-hover: var(
+    --smooth_dark--ui_corner_action-hover,
+    rgb(64, 69, 80)
+  );
+  --theme--ui_corner_action-active: var(
+    --smooth_dark--ui_corner_action-active,
+    rgb(77, 82, 93)
+  );
+
+  --theme--icon: rgb(255, 255, 255, 0.87);
+  --theme--icon_secondary: rgba(255, 255, 255, 0.6);
+
+  --theme--text: rgba(255, 255, 255, 0.87);
+  --theme--text_secondary: rgb(255, 255, 255, 0.6);
+
+  --theme--highlight_red: var(--smooth_dark--highlight_red);
+  --theme--highlight_orange: var(--smooth_dark--highlight_orange);
+  --theme--highlight_yellow: var(--smooth_dark--highlight_yellow);
+  --theme--highlight_green: var(--smooth_dark--highlight_green);
+  --theme--highlight_blue: var(--smooth_dark--highlight_blue);
+  --theme--highlight_purple: var(--smooth_dark--highlight_purple);
+  --theme--highlight_pink: var(--smooth_dark--highlight_pink);
+  --theme--highlight_gray: var(--smooth_dark--highlight_gray);
+  --theme--highlight_brown: var(--smooth_dark--highlight_brown);
+
+  --theme--highlight_gray-text: rgba(255, 255, 255, 0.87); /* stays the same for both */
+  --theme--highlight_brown-text: var(--smooth_dark--highlight-text);
+  --theme--highlight_orange-text: var(--smooth_dark--highlight-text);
+  --theme--highlight_yellow-text: var(--smooth_dark--highlight-text);
+  --theme--highlight_green-text: var(--smooth_dark--highlight-text);
+  --theme--highlight_blue-text: var(--smooth_dark--highlight-text);
+  --theme--highlight_purple-text: var(--smooth_dark--highlight-text);
+  --theme--highlight_pink-text: var(--smooth_dark--highlight-text);
+  --theme--highlight_red-text: var(--smooth_dark--highlight-text);
+
+  --theme--callout_red: var(--smooth_dark--callout_red);
+  --theme--callout_orange: var(--smooth_dark--callout_orange);
+  --theme--callout_yellow: var(--smooth_dark--callout_yellow);
+  --theme--callout_green: var(--smooth_dark--callout_green);
+  --theme--callout_blue: var(--smooth_dark--callout_blue);
+  --theme--callout_purple: var(--smooth_dark--callout_purple);
+  --theme--callout_pink: var(--smooth_dark--callout_pink);
+  --theme--callout_gray: var(--smooth_dark--callout_gray);
+  --theme--callout_brown: var(--smooth_dark--callout_brown);
+
+  --theme--callout_gray-text: var(--theme--text);
+  --theme--callout_brown-text: var(--theme--text);
+  --theme--callout_orange-text: var(--theme--text);
+  --theme--callout_yellow-text: var(--theme--text);
+  --theme--callout_green-text: var(--theme--text);
+  --theme--callout_blue-text: var(--theme--text);
+  --theme--callout_purple-text: var(--theme--text);
+  --theme--callout_pink-text: var(--theme--text);
+  --theme--callout_red-text: var(--theme--text);
+
+  --theme--tag_red: var(--smooth_dark--tag_red);
+  --theme--tag_orange: var(--smooth_dark--tag_orange);
+  --theme--tag_yellow: var(--smooth_dark--tag_yellow);
+  --theme--tag_green: var(--smooth_dark--tag_green);
+  --theme--tag_blue: var(--smooth_dark--tag_blue);
+  --theme--tag_purple: var(--smooth_dark--tag_purple);
+  --theme--tag_pink: var(--smooth_dark--tag_pink);
+  --theme--tag_gray: var(--smooth_dark--tag_gray);
+  --theme--tag_light_gray: var(--smooth_dark--tag_light_gray);
+  --theme--tag_brown: var(--smooth_dark--tag_brown);
+
+  --theme--tag_default: rgba(255, 255, 255, 0.14);
+  --theme--tag_default-text: var(--smooth_dark--tag-text);
+  --theme--tag_light_gray-text: var(--smooth_dark--tag-text);
+  --theme--tag_gray-text: var(--smooth_dark--tag-text);
+  --theme--tag_brown-text: var(--smooth_dark--tag-text);
+  --theme--tag_orange-text: var(--smooth_dark--tag-text);
+  --theme--tag_yellow-text: var(--smooth_dark--tag-text);
+  --theme--tag_green-text: var(--smooth_dark--tag-text);
+  --theme--tag_blue-text: var(--smooth_dark--tag-text);
+  --theme--tag_purple-text: var(--smooth_dark--tag-text);
+  --theme--tag_pink-text: var(--smooth_dark--tag-text);
+  --theme--tag_red-text: var(--smooth_dark--tag-text);
+
+  --theme--board_red: var(--smooth_dark--board_red);
+  --theme--board_orange: var(--smooth_dark--board_orange);
+  --theme--board_yellow: var(--smooth_dark--board_yellow);
+  --theme--board_green: var(--smooth_dark--board_green);
+  --theme--board_blue: var(--smooth_dark--board_blue);
+  --theme--board_purple: var(--smooth_dark--board_purple);
+  --theme--board_pink: var(--smooth_dark--board_pink);
+  --theme--board_gray: var(--smooth_dark--board_gray);
+  --theme--board_light_gray: var(--smooth_dark--board_light_gray);
+  --theme--board_brown: var(--smooth_dark--board_brown);
+
+  --theme--board_light_gray-card: var(--smooth_dark--board-card);
+  --theme--board_gray-card: var(--smooth_dark--board-card);
+  --theme--board_brown-card: var(--smooth_dark--board-card);
+  --theme--board_orange-card: var(--smooth_dark--board-card);
+  --theme--board_yellow-card: var(--smooth_dark--board-card);
+  --theme--board_green-card: var(--smooth_dark--board-card);
+  --theme--board_blue-card: var(--smooth_dark--board-card);
+  --theme--board_purple-card: var(--smooth_dark--board-card);
+  --theme--board_pink-card: var(--smooth_dark--board-card);
+  --theme--board_red-card: var(--smooth_dark--board-card);
+  --theme--board_light_gray-text: var(--theme--text);
+  --theme--board_gray-text: var(--theme--text);
+  --theme--board_brown-text: var(--theme--text);
+  --theme--board_orange-text: var(--theme--text);
+  --theme--board_yellow-text: var(--theme--text);
+  --theme--board_green-text: var(--theme--text);
+  --theme--board_blue-text: var(--theme--text);
+  --theme--board_purple-text: var(--theme--text);
+  --theme--board_pink-text: var(--theme--text);
+  --theme--board_red-text: var(--theme--text);
+  --theme--board_light_gray-card_text: inherit;
+  --theme--board_gray-card_text: inherit;
+  --theme--board_brown-card_text: inherit;
+  --theme--board_orange-card_text: inherit;
+  --theme--board_yellow-card_text: inherit;
+  --theme--board_green-card_text: inherit;
+  --theme--board_blue-card_text: inherit;
+  --theme--board_purple-card_text: inherit;
+  --theme--board_pink-card_text: inherit;
+  --theme--board_red-card_text: inherit;
+
+  --theme--code_inline-text: #adf5c3;
+  --theme--code_inline: rgba(127, 127, 127, 0.2);
+
+  --theme--code: var(--smooth_dark--code, rgba(66, 71, 82, 0.8));
+  --theme--code_plain: var(--theme--text);
+  --theme--code_property: var(--theme--text_yellow);
+  --theme--code_tag: var(--theme--text_red);
+  --theme--code_boolean: var(--theme--text_blue);
+  --theme--code_number: var(--theme--text_red);
+  --theme--code_constant: var(--theme--text_yellow);
+  --theme--code_symbol: var(--theme--text_yellow);
+  --theme--code_deleted: var(--theme--text_red);
+  --theme--code_selector: var(--theme--text_yellow);
+  --theme--code_attr-name: var(--theme--text_red);
+  --theme--code_string: var(--theme--text_green);
+  --theme--code_char: var(--theme--code_string);
+  --theme--code_builtin: var(--theme--text_yellow);
+  --theme--code_inserted: var(--theme--text_green);
+  --theme--code_operator: var(--theme--text_blue);
+  --theme--code_entity: var(--theme--text_green);
+  --theme--code_url: var(--theme--code_string);
+  --theme--code_variable: var(--theme--text_green);
+  --theme--code_comment: var(--theme--text_gray);
+  --theme--code_cdata: var(--theme--code_comment);
+  --theme--code_prolog: var(--theme--code_comment);
+  --theme--code_doctype: var(--theme--code_comment);
+  --theme--code_atrule: var(--theme--text_blue);
+  --theme--code_attr-value: var(--theme--text_green);
+  --theme--code_keyword: var(--theme--text_purple);
+  --theme--code_regex: var(--theme--text_orange);
+  --theme--code_important: var(--theme--text_orange);
+  --theme--code_function: var(--theme--text_yellow);
+  --theme--code_class-name: var(--theme--code_function);
+  --theme--code_parameter: var(--theme--text_orange);
+  --theme--code_decorator: var(--theme--text_blue);
+  --theme--code_id: var(--theme--text_purple);
+  --theme--code_class: var(--theme--text_pink);
+  --theme--code_pseudo-element: var(--theme--text_red);
+  --theme--code_pseudo-class: var(--theme--text_orange);
+  --theme--code_attribute: var(--theme--text_blue);
+  --theme--code_value: var(--theme--text_orange);
+  --theme--code_unit: var(--theme--code_number);
+  --theme--code_punctuation: var(--theme--code_plain);
+  --theme--code_annotation: var(--theme--text_blue);
+}

--- a/smooth-dark/variables.css
+++ b/smooth-dark/variables.css
@@ -9,22 +9,19 @@
   --smooth_dark--board-card: rgba(255, 255, 255, 0.05);
   --smooth_dark--tag-text: #fff;
 
-  --theme--accent_blue: var(--smooth_dark--accent_blue, rgb(255, 171, 0));
+  --theme--accent_blue: var(--smooth_dark--accent_blue);
   --theme--accent_blue-selection: var(
     --smooth_dark--accent_blue-selection,
     rgba(255, 171, 0, 0.2)
   );
-  --theme--accent_blue-hover: var(--smooth_dark--accent_blue-hover, rgb(255, 177, 18));
-  --theme--accent_blue-active: var(--smooth_dark--accent_blue-active, rgb(255, 184, 41));
-  --theme--accent_blue-text: var(--smooth_dark--accent_blue-text, #fff);
-  --theme--accent_red: var(--smooth_dark--accent_red, #eb5757);
-  --theme--accent_red-button: var(
-    --smooth_dark--accent_red-button,
-    rgba(235, 87, 87, 0.1)
-  );
-  --theme--accent_red-text: var(--smooth_dark--accent_red-text, #fff);
-  --a: ;
-  --theme--bg: var(--smooth_dark--bg, rgb(33, 39, 52));
+  --theme--accent_blue-hover: var(--smooth_dark--accent_blue-hover);
+  --theme--accent_blue-active: var(--smooth_dark--accent_blue-active);
+  --theme--accent_blue-text: var(--smooth_dark--accent_blue-text);
+  --theme--accent_red: var(--smooth_dark--accent_red);
+  --theme--accent_red-button: var(--smooth_dark--accent_red-button);
+  --theme--accent_red-text: var(--smooth_dark--accent_red-text);
+
+  --theme--bg: var(--smooth_dark--bg);
   --theme--bg_secondary: var(--smooth_dark--bg_secondary);
   --theme--bg_card: var(--smooth_dark--bg_card);
 
@@ -38,15 +35,9 @@
   --theme--ui_interactive-active: rgba(255, 255, 255, 0.16);
   --theme--ui_toggle-on: var(--theme--accent_blue);
   --theme--ui_toggle-off: rgba(255, 255, 255, 0.05);
-  --theme--ui_corner_action: var(--smooth_dark--ui_corner_action, rgb(53, 58, 70));
-  --theme--ui_corner_action-hover: var(
-    --smooth_dark--ui_corner_action-hover,
-    rgb(64, 69, 80)
-  );
-  --theme--ui_corner_action-active: var(
-    --smooth_dark--ui_corner_action-active,
-    rgb(77, 82, 93)
-  );
+  --theme--ui_corner_action: var(--smooth_dark--ui_corner_action);
+  --theme--ui_corner_action-hover: var(--smooth_dark--ui_corner_action-hover);
+  --theme--ui_corner_action-active: var(--smooth_dark--ui_corner_action-active);
 
   --theme--icon: rgb(255, 255, 255, 0.87);
   --theme--icon_secondary: rgba(255, 255, 255, 0.6);
@@ -163,7 +154,7 @@
   --theme--code_inline-text: #adf5c3;
   --theme--code_inline: rgba(127, 127, 127, 0.2);
 
-  --theme--code: var(--smooth_dark--code, rgba(66, 71, 82, 0.8));
+  --theme--code: var(--smooth_dark--code);
   --theme--code_plain: var(--theme--text);
   --theme--code_property: var(--theme--text_yellow);
   --theme--code_tag: var(--theme--text_red);

--- a/theming/theme.css
+++ b/theming/theme.css
@@ -48,8 +48,7 @@ body,
 .notion-update-sidebar-tab-comments-header,
 .notion-update-sidebar-tab-comments-header + div,
 .notion-code-block > div > div > [style*='background: '][style$='padding-right: 105px;'],
-[style*='z-index: 84'],
-iframe {
+[style*='z-index: 84'] {
   background: var(--theme--bg) !important;
 }
 .notion-timeline-item-row + div > div > div,

--- a/theming/theme.css
+++ b/theming/theme.css
@@ -48,7 +48,8 @@ body,
 .notion-update-sidebar-tab-comments-header,
 .notion-update-sidebar-tab-comments-header + div,
 .notion-code-block > div > div > [style*='background: '][style$='padding-right: 105px;'],
-[style*='z-index: 84'] {
+[style*='z-index: 84'],
+iframe {
   background: var(--theme--bg) !important;
 }
 .notion-timeline-item-row + div > div > div,


### PR DESCRIPTION
**Which bug report or feature request do these changes address?**
notion-enhancer/notion-enhancer#851 
a dark theme with customisable options - see screenshot - options and their defaults
![image](https://user-images.githubusercontent.com/88137137/154836937-bdba07f2-8770-410b-833a-17b2ebe8f998.png)

**What does your code do and why?**
`app.css`: an option to add rounding to highlights - selectors are the same as the ones in `theming/colors.css`
`theme.mjs`: sets many colours based on selected options
the function `rgbLinearShade` lightens or darkens a specified colour, the same as overlaying black/white on top of the colour with the specified opacity.
`ui_corner_action`, `ui_corner_action-hover`, `ui_corner_action-active`, `code`, `bg_secondary` and `bg_card` are lighter/darker tints of the background.
primary and secondary colours are also configurable, similar to the ones in the `dark+` theme.

colours for highlight-text, text, highlight, callout, tag and boards are set depending on which colour profile is selected.
`pastel` has lighter and less saturated colours - highlight-text is made black(ish) as there is little contrast if it stays white
`regular` has darker and more saturated colours, highlight-text stays white
the colours for these are all from LCh colours with the same chrominance and lightness (specific values in comments). most blues are altered to be less saturated (LCh is not very accurate in the blues).
theme colours are not set directly to work with other themes.

`variables.css`: some colours have opacity to change based on the existing background. colours that are lighter/darker tints of the background but need to have 100% opacity are set in `theme.mjs`. 
`theming/theme.css`: I found that transparent iframes use the default Notion background. Easily fixed by setting `iframe` to the custom background.

`smooth-dark.png`: file is created but empty so no changes need to be made in `mod.json`. Replace with your theme screenshot with the default options pls :)

**screenshots:**
default settings
![image](https://user-images.githubusercontent.com/88137137/154836283-965365ca-a538-4e69-b3ee-4c4aa878f2ec.png)

grey: background `#1F1F1F`, color profile `regular`
![image](https://user-images.githubusercontent.com/88137137/154836470-69f1cb32-36f4-46b0-ab54-f21e34ca2a8f.png)

a more saturated colour: background `#40121A`
![image](https://user-images.githubusercontent.com/88137137/154836631-a2f4f674-87ac-41a1-aad6-309d5d475c6a.png)
