### PR TITLE
Fix weekly-view for new Notion databases

### DIFF
--- a/weekly-view/client.mjs
+++ b/weekly-view/client.mjs
@@ -22,20 +22,20 @@ export default async function ({ web }, db) {
     document.querySelectorAll(viewSelector).forEach(async ($view) => {    
       let currentText;  
       // Get view controls children nodes, convert to array, filter out non-text
-      const viewNodes = []
+      const $viewNodes = []
         .slice.call($view.querySelector(viewControlSelector).children)
         .filter(node => node.tagName.toLowerCase().match(/(div|span)/g));
 
       // Find current view by analyzing children (which changes on viewport) 
-      if (viewNodes.length === 1)
+      if ($viewNodes.length === 1)
       {
         // Mobile: Simple dropdown button (like legacy), text is current view
-        currentText = viewNodes[0].innerText.toLowerCase();
+        currentText = $viewNodes[0].innerText.toLowerCase();
       } else {
         // Wide/Desktop: Tabs listed, current view indicated by border style
-        currentText = viewNodes
+        currentText = $viewNodes
           // Find selected view by border style (possibly fragile)
-          .filter((e) => e.children[0].style.borderBottomWidth.toString() === '2px')[0]
+          .filter(($e) => $e.children[0].style.borderBottomWidth.toString() === '2px')[0]
           .innerText.toLowerCase();
       }
       

--- a/weekly-view/client.mjs
+++ b/weekly-view/client.mjs
@@ -4,26 +4,43 @@
  * (https://notion-enhancer.github.io/) under the MIT license
  */
 
-"use strict";
+'use strict';
 
 export default async function ({ web }, db) {
-  const pageSelector = ".notion-page-content",
-    calendarSelector = ".notion-calendar-view",
+  const pageSelector = '.notion-page-content',
+    calendarSelector = '.notion-calendar-view',
     collectionSelector =
-            ".notion-page-content > .notion-selectable.notion-collection_view-block",
-    viewSelector = ":scope>div>div>div>div>div",
+            '.notion-page-content > .notion-selectable.notion-collection_view-block',
+    viewSelector = ':scope>div>div>div>div>div',
     todaySelector = '.notion-calendar-view-day[style*="background"]',
     weekSelector = '[style^="position: relative; display: flex; height: "]',
     toolbarBtnSelector =
-            ".notion-calendar-view > :first-child > :first-child > :first-child > :nth-last-child(2)";
+            '.notion-calendar-view > :first-child > :first-child > :first-child > :nth-last-child(2)';
 
   const transformCalendarView = () => {
     const $page = document.querySelector(pageSelector);
-    document.querySelectorAll(collectionSelector).forEach(async ($view) => {
+    document.querySelectorAll(collectionSelector).forEach(async ($view) => {      // Get view controls children nodes, convert to array, filter out non-text
+      const viewNodes = []
+        .slice.call($view.querySelector(viewSelector).children)
+        .filter(node => node.tagName.toLowerCase().match(/(div|span)/g));
+      let currentText;
 
-      const currentText = [].slice.call($view.querySelector(viewSelector).children).filter((e) => e.children[0].style.borderBottomWidth.toString() === "2px" )[0].innerText.toLowerCase();
-
-      if (currentText !== "weekly")
+      // Find current view by analyzing children (which changes on viewport) 
+      if (viewNodes.length === 1)
+      {
+        // Mobile: Simple dropdown button (like legacy), text is current view
+        currentText = viewNodes[0].innerText.toLowerCase();
+      } else {
+        // Wide/Desktop: Tabs listed, current view indicated by border style
+        currentText = viewNodes
+          // Find selected view by border style (possibly fragile)
+          .filter((e) => e.children[0].style.borderBottomWidth.toString() === '2px' )[0]
+          // Format
+          .innerText.toLowerCase();
+      }
+        
+      // Check if view is weekly
+      if (currentText !== 'weekly')
         return;
 
       const $calendar =
@@ -34,10 +51,8 @@ export default async function ({ web }, db) {
       await new Promise((res, rej) => requestAnimationFrame(res));
       if ($page) {
         for (const $week of $calendar.querySelectorAll(weekSelector)) {
-          if (!$week.querySelector(todaySelector)) {
-            $week.style.height = "0";
-            $week.style.display = "none";
-          }
+          if (!$week.querySelector(todaySelector)) 
+            $week.style.visibility = 'hidden';
         }
       } else {
         const $weekContainer =
@@ -47,8 +62,8 @@ export default async function ({ web }, db) {
             $weekContainer.style.maxHeight = $week.style.height;
             break;
           } else {
-            $week.style.height = "0";
-            $week.style.opacity = "0";
+            $week.style.height = '0';
+            $week.style.opacity = '0';
           }
         }
       }

--- a/weekly-view/client.mjs
+++ b/weekly-view/client.mjs
@@ -9,21 +9,22 @@
 export default async function ({ web }, db) {
   const pageSelector = '.notion-page-content',
     calendarSelector = '.notion-calendar-view',
-    collectionSelector =
-            '.notion-page-content > .notion-selectable.notion-collection_view-block',
-    viewSelector = ':scope>div>div>div>div>div',
+    viewSelector =
+      '.notion-page-content > .notion-selectable.notion-collection_view-block',
+    viewControlSelector = ':scope>div>div>div>div>div',
     todaySelector = '.notion-calendar-view-day[style*="background"]',
     weekSelector = '[style^="position: relative; display: flex; height: "]',
     toolbarBtnSelector =
-            '.notion-calendar-view > :first-child > :first-child > :first-child > :nth-last-child(2)';
+      '.notion-calendar-view > :first-child > :first-child > :first-child > :nth-last-child(2)';
 
   const transformCalendarView = () => {
     const $page = document.querySelector(pageSelector);
-    document.querySelectorAll(collectionSelector).forEach(async ($view) => {      // Get view controls children nodes, convert to array, filter out non-text
+    document.querySelectorAll(viewSelector).forEach(async ($view) => {    
+      let currentText;  
+      // Get view controls children nodes, convert to array, filter out non-text
       const viewNodes = []
-        .slice.call($view.querySelector(viewSelector).children)
+        .slice.call($view.querySelector(viewControlSelector).children)
         .filter(node => node.tagName.toLowerCase().match(/(div|span)/g));
-      let currentText;
 
       // Find current view by analyzing children (which changes on viewport) 
       if (viewNodes.length === 1)
@@ -34,36 +35,33 @@ export default async function ({ web }, db) {
         // Wide/Desktop: Tabs listed, current view indicated by border style
         currentText = viewNodes
           // Find selected view by border style (possibly fragile)
-          .filter((e) => e.children[0].style.borderBottomWidth.toString() === '2px' )[0]
-          // Format
+          .filter((e) => e.children[0].style.borderBottomWidth.toString() === '2px')[0]
           .innerText.toLowerCase();
       }
-        
-      // Check if view is weekly
-      if (currentText !== 'weekly')
-        return;
+      
+      if (currentText !== 'weekly') return;
 
-      const $calendar =
-                $view.parentElement.parentElement.parentElement.parentElement;
+      const $calendar = $view.parentElement.parentElement.parentElement.parentElement;
       if (!$calendar.querySelector(todaySelector)) {
         $calendar.querySelector(toolbarBtnSelector).click();
       }
       await new Promise((res, rej) => requestAnimationFrame(res));
       if ($page) {
         for (const $week of $calendar.querySelectorAll(weekSelector)) {
-          if (!$week.querySelector(todaySelector)) 
+          if (!$week.querySelector(todaySelector)) {
+            $week.style.height = 0;
             $week.style.visibility = 'hidden';
+          }
         }
       } else {
-        const $weekContainer =
-                    $calendar.querySelector(weekSelector).parentElement;
+        const $weekContainer = $calendar.querySelector(weekSelector).parentElement;
         for (const $week of $calendar.querySelectorAll(weekSelector)) {
           if ($week.querySelector(todaySelector)) {
             $weekContainer.style.maxHeight = $week.style.height;
             break;
           } else {
             $week.style.height = '0';
-            $week.style.opacity = '0';
+            $week.style.visibility = 'hidden';
           }
         }
       }

--- a/weekly-view/client.mjs
+++ b/weekly-view/client.mjs
@@ -4,39 +4,51 @@
  * (https://notion-enhancer.github.io/) under the MIT license
  */
 
-'use strict';
+"use strict";
 
 export default async function ({ web }, db) {
-  const pageSelector = '.notion-page-content',
-    calendarSelector = '.notion-calendar-view',
-    viewSelector = '.notion-collection-view-select:not([data-weekly-view])',
+  const pageSelector = ".notion-page-content",
+    calendarSelector = ".notion-calendar-view",
+    collectionSelector =
+            ".notion-page-content > .notion-selectable.notion-collection_view-block",
+    viewSelector = ":scope>div>div>div>div>div",
     todaySelector = '.notion-calendar-view-day[style*="background"]',
     weekSelector = '[style^="position: relative; display: flex; height: "]',
     toolbarBtnSelector =
-      '.notion-calendar-view > :first-child > :first-child > :first-child > :nth-last-child(2)';
+            ".notion-calendar-view > :first-child > :first-child > :first-child > :nth-last-child(2)";
 
   const transformCalendarView = () => {
     const $page = document.querySelector(pageSelector);
-    document.querySelectorAll(viewSelector).forEach(async ($view) => {
-      if ($view.innerText.toLowerCase() !== 'weekly') return;
-      const $calendar = $view.parentElement.parentElement.parentElement.parentElement;
+    document.querySelectorAll(collectionSelector).forEach(async ($view) => {
+
+      const currentText = [].slice.call($view.querySelector(viewSelector).children).filter((e) => e.children[0].style.borderBottomWidth.toString() === "2px" )[0].innerText.toLowerCase();
+
+      if (currentText !== "weekly")
+        return;
+
+      const $calendar =
+                $view.parentElement.parentElement.parentElement.parentElement;
       if (!$calendar.querySelector(todaySelector)) {
         $calendar.querySelector(toolbarBtnSelector).click();
       }
       await new Promise((res, rej) => requestAnimationFrame(res));
       if ($page) {
         for (const $week of $calendar.querySelectorAll(weekSelector)) {
-          if (!$week.querySelector(todaySelector)) $week.style.height = '0';
+          if (!$week.querySelector(todaySelector)) {
+            $week.style.height = "0";
+            $week.style.display = "none";
+          }
         }
       } else {
-        const $weekContainer = $calendar.querySelector(weekSelector).parentElement;
+        const $weekContainer =
+                    $calendar.querySelector(weekSelector).parentElement;
         for (const $week of $calendar.querySelectorAll(weekSelector)) {
           if ($week.querySelector(todaySelector)) {
             $weekContainer.style.maxHeight = $week.style.height;
             break;
           } else {
-            $week.style.height = '0';
-            $week.style.opacity = '0';
+            $week.style.height = "0";
+            $week.style.opacity = "0";
           }
         }
       }


### PR DESCRIPTION
**Which bug report or feature request do these changes address?**

Fixed #98, where weekly-view failed to target the current view in Notion's new database layout.

**What does your code do and why?**
 
This PR updates that code to extract the current view's name correctly from the new Notion databases layout at desktop and mobile sizes. It targets the container for the new view selection controls and finds the current view name within. 

On desktop (where many tabs are presented), it filters through the tabs for the current view by the border style (as there is no class or attribute to target) 
![image](https://user-images.githubusercontent.com/9386314/159346891-f7709bd7-e781-4610-a39f-831f7a41bb74.png)

On mobile (where the's only a single dropdown button with the current view name, like the old database view 
![image](https://user-images.githubusercontent.com/9386314/159347063-c5d9d606-ee7e-4bcc-bf8d-fa8479be6289.png)

It hides extraneous weeks by setting the height to 0 and visibility to none. 

It doens't modify any other code pertaining to the week filtering and picking methodology. 

Tested on the latest injecteed desktop app for macOS Monterey 12.2.1. 
