### PR TITLE
fix: make the notion-enhancer menu visible again

### DIFF
--- a/menu/client.mjs
+++ b/menu/client.mjs
@@ -11,7 +11,7 @@ const notificationsURL = 'https://notion-enhancer.github.io/notifications.json';
 export default async function ({ env, fs, storage, registry, web }, db) {
   web.addHotkeyListener(await db.get(['hotkey']), env.focusMenu);
 
-  const sidebarSelector = '.notion-sidebar-container .notion-sidebar > div:nth-child(4)';
+  const sidebarSelector = '.notion-sidebar-container .notion-sidebar > div:nth-child(3) > div > div:nth-child(2)';
   await web.whenReady([sidebarSelector]);
 
   const $sidebarLink = web.html`<div class="enhancer--sidebarMenuLink" role="button" tabindex="0">


### PR DESCRIPTION
**Which bug report or feature request do these changes address?**
This PR address to the announcement made in the discord channel that the notion-enhancer menu was no longer visible
Fixed notion-enhancer/desktop#762

**What does your code do and why?**
It changes the query selector to decide where the notion-enhancer menu will be inserted

***NOTE:** I only checked my code change with the extension, but it should work for the desktop app too*