### PR TITLE
Fixed bypass preview

### DIFF
--- a/bypass-preview/client.mjs
+++ b/bypass-preview/client.mjs
@@ -4,28 +4,34 @@
  * (https://notion-enhancer.github.io/) under the MIT license
  */
 
-'use strict';
+"use strict";
 
 export default function ({ web, notion }, db) {
   let _openPage = {};
+
   const getCurrentPage = () => ({
-    type: web.queryParams().get('p') ? 'preview' : 'page',
+    type: web.queryParams().get("p") ? "preview" : "page",
     id: notion.getPageID(),
   });
 
   const interceptPreview = () => {
     const currentPage = getCurrentPage();
-    if (currentPage.id !== _openPage.id || currentPage.type !== _openPage.type) {
+    if (
+      currentPage.id !== _openPage.id ||
+      currentPage.type !== _openPage.type
+    ) {
       const $openAsPage = document.querySelector(
-        '.notion-peek-renderer [style*="height: 45px;"] a'
+        ".notion-peek-renderer a > div"
       );
+
       if ($openAsPage) {
-        if (currentPage.id === _openPage.id && currentPage.type === 'preview') {
+        if (currentPage.id === _openPage.id && currentPage.type === "preview") {
           history.back();
         } else $openAsPage.click();
       }
+
       _openPage = getCurrentPage();
     }
   };
-  web.addDocumentObserver(interceptPreview, ['.notion-peek-renderer']);
+  web.addDocumentObserver(interceptPreview, [".notion-peek-renderer"]);
 }


### PR DESCRIPTION
BEFORE MAKING A PULL REQUEST, PLEASE READ THE
[CONTRIBUTING](https://notion-enhancer.github.io/about/contributing) GUIDE.

PULL REQUESTS THAT DO NOT PROPERLY FILL
IN THE TEMPLATE MAY BE IGNORED OR REJECTED.
YOU MUST DELETE ALL TEXT ON OR ABOVE THIS LINE BEFORE SUBMITTING.

**Which bug report or feature request do these changes address?**
Not sure if there is a bug report on this but bypass preview has made it so that it is impossible to even get a preview sometime recently. Currently, if you click on a button that turns into a preview, it will do nothing.

**What does your code do and why?**
Fixes the selector to what it should be now - this will allow for the button to actually be clicked instead of getting an undefined $openAsPage button. Also some small style changes