### PR TITLE
Add "hide default page icons" tweak

### DIFF
--- a/tweaks/client.css
+++ b/tweaks/client.css
@@ -1,5 +1,6 @@
 /**
  * notion-enhancer: tweaks
+ * (c) 2024 1280px
  * (c) 2021 dragonwocky <thedragonring.bod@gmail.com> (https://dragonwocky.me/)
  * (c) 2020 arecsu
  * (https://notion-enhancer.github.io/) under the MIT license
@@ -57,6 +58,13 @@
 
 .enhancer--tweak-hide_slash_for_commands [contenteditable]:empty:after {
   content: ' ' !important;
+}
+
+.enhancer--tweak-hide_default_page_icons
+  .notion-sidebar a > div > div:has(.notion-record-icon svg.page),
+.enhancer--tweak-hide_default_page_icons
+  .layout a > div > div > div > div:has(.notion-record-icon svg.page) {
+  display: none !important;
 }
 
 .enhancer--tweak-thicker_bold .notion-page-content span[style*='font-weight:600'] {

--- a/tweaks/client.mjs
+++ b/tweaks/client.mjs
@@ -34,6 +34,7 @@ export default async function ({ web }, db) {
     'normalise_table_scroll',
     'hide_help',
     'hide_slash_for_commands',
+    'hide_default_page_icons',
     'snappy_transitions',
     'thicker_bold',
     'spaced_lines',

--- a/tweaks/mod.json
+++ b/tweaks/mod.json
@@ -1,7 +1,7 @@
 {
   "name": "tweaks",
   "id": "5174a483-c88d-4bf8-a95f-35cd330b76e2",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "common style/layout changes and custom code insertion. check out the [tweaks page](https://notion-enhancer.github.io/advanced/tweaks) for more.",
   "tags": ["extension", "customisation"],
   "authors": [
@@ -72,6 +72,13 @@
       "key": "tweak.hide_slash_for_commands",
       "label": "hide \"Type '/' for commands\"",
       "value": false
+    },
+    {
+      "type": "toggle",
+      "key": "tweak.hide_default_page_icons",
+      "label": "hide default page icons",
+      "tooltip": "hide **default (svg.page)** page icons, both in sidebar and opened pages, to save some space",
+      "value": true
     },
     {
       "type": "toggle",


### PR DESCRIPTION
<!-- BEFORE MAKING A PULL REQUEST, PLEASE READ THE
[CONTRIBUTING](https://notion-enhancer.github.io/about/contributing) GUIDE.

PULL REQUESTS THAT DO NOT PROPERLY FILL
IN THE TEMPLATE MAY BE IGNORED OR REJECTED.
YOU MUST DELETE ALL TEXT ON OR ABOVE THIS LINE BEFORE SUBMITTING. -->

See also: https://github.com/notion-enhancer/notion-enhancer/pull/819

**Which bug report or feature request do these changes address?**
Add an aforementioned option in "Tweaks" section. When enabled, it hides default page icons (![изображение](https://github.com/notion-enhancer/repo/assets/71165491/caaea105-238c-4a86-87f2-35a5d4f0c6fa)), both in sidebar and page links. It intentionally does not hide the big default icon on the top of the page, so it's still possible to change the icon.
![Снимок экрана от 2024-01-26 21-27-16](https://github.com/notion-enhancer/repo/assets/71165491/5bc7fa48-7ce7-4b86-83a1-7675de011eea)


**What does your code do and why?**
2 simple CSS selectors powered by :has() operator (which, as of now, [has been supported by all modern browsers](https://caniuse.com/css-has) for at least half a year — except for Firefox, which added it 2 months ago). It also bumps "Tweaks" version to 0.3.0, just in case.
